### PR TITLE
Laravel 5.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 dist: trusty
 
 php:
-  - 7.1
   - 7.2
+  - 7.3
 
 services:
   - rabbitmq

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 A client for publishing and listening for routed exchange messages.
 
-# Requirements
-* PHP 7.1 or higher
-* Laravel [5.5](https://laravel.com/docs/5.5) or [5.6](https://laravel.com/docs/5.6)
+# Current Requirements
+* PHP 7.2 - PHP 7.3
+* Laravel [5.8](https://laravel.com/docs/5.8)
 
 # Installation
 Via composer

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
   "type": "libr",
   "license": "MIT",
   "require": {
-    "php": "7.1.*||7.2.*",
-    "illuminate/support": "5.5.*||5.6.*||5.7.*",
-    "php-amqplib/php-amqplib": "^2.7.2"
+    "php": "7.2.*||7.3.*",
+    "illuminate/support": "5.8.*",
+    "php-amqplib/php-amqplib": "^2.9.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "7.0.*",
-    "orchestra/testbench": "3.5.*||3.6.*||3.7.*"
+    "phpunit/phpunit": "8.0.*",
+    "orchestra/testbench": "3.8.*"
   },
   "prefer-stable": true,
   "minimum-stability": "stable",

--- a/tests/AmqpRouteMessengerTest.php
+++ b/tests/AmqpRouteMessengerTest.php
@@ -11,7 +11,7 @@ class AmqpRouteMessengerTest extends Orchestra\Testbench\TestCase
     /**
      * Setup the test environment.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
- Adding support for Laravel 5.8.
- Removing support for Laravel 5.5 - 5.7.
- Removing support for PHP 7.1.
- Adding support for PHP 7.3.
- Adding requirement for PHPUnit 8.
- Updating dependencies.